### PR TITLE
First draft of Perlmutter run script.

### DIFF
--- a/EB/CNS/Exec/Combustor/cns_prob.F90
+++ b/EB/CNS/Exec/Combustor/cns_prob.F90
@@ -49,7 +49,6 @@ end subroutine amrex_probinit
 
 subroutine cns_initdata(level, time, lo, hi, u, ulo, uhi, dx, prob_lo) bind(C, name="cns_initdata")
   use amrex_fort_module, only : rt => amrex_real
-  use cns_physics_module, only : gamma, cv
   use cns_module, only : nvar
   use probdata_module, only : interior_state
   implicit none

--- a/EB/CNS/Exec/ShockRef/cns_prob.F90
+++ b/EB/CNS/Exec/ShockRef/cns_prob.F90
@@ -35,7 +35,7 @@ end subroutine amrex_probinit
 subroutine cns_initdata(level, time, lo, hi, u, ulo, uhi, dx, prob_lo) bind(C, name="cns_initdata")
   use amrex_fort_module, only : rt => amrex_real
   use cns_physics_module, only : gamma, cv
-  use cns_module, only : center, nvar, urho, umx, umy, umz, ueden, ueint, utemp
+  use cns_module, only : nvar, urho, umx, umy, umz, ueden, ueint, utemp
   use probdata_module, only : p0,p1,rho0,rho1,v0,v1,x1
   implicit none
   integer, intent(in) :: level, lo(3), hi(3), ulo(3), uhi(3)

--- a/EB/CNS/Source/diffusion/cns_eb_diff_mod.F90
+++ b/EB/CNS/Source/diffusion/cns_eb_diff_mod.F90
@@ -38,7 +38,6 @@ contains
     real(rt) :: tauxx, tauyy, tauzz, tauxy, tauxz, tauyz, muf, xif
     real(rt) :: dudx, dudy, dudz, dvdx, dvdy, dwdx, dwdz, divu, dTdx
     real(rt) :: dvdz, dwdy, dTdy, dTdz
-    integer  :: nbrlo(-1:1,-1:1,-1:1), nbrhi(-1:1,-1:1,-1:1)
     integer  :: ihip, ihim, ilop, ilom, jhip, jhim, jlop, jlom, khip, khim, klop, klom
     real(rt) :: wlo, whi
     real(rt), parameter :: weights(0:2) = [0.d0, 1.d0, 0.5d0]

--- a/EB/MacProj/main.cpp
+++ b/EB/MacProj/main.cpp
@@ -88,7 +88,7 @@ int main (int argc, char* argv[])
         MultiFab divu(grids, dmap, 1, 0, MFInfo(), factory);
         EB_computeDivergence(divu, amrex::GetArrOfConstPtrs(vel), geom, false);
         amrex::Print() << "\nmax-norm of divu before projection is " << divu.norm0() << "\n" << std::endl;
-        plotfile_mf.copy(divu,0,AMREX_SPACEDIM,1);
+        plotfile_mf.ParallelCopy(divu,0,AMREX_SPACEDIM,1);
 
         MacProjector macproj({amrex::GetArrOfPtrs(vel)},       // mac velocity
                              MLMG::Location::FaceCenter,
@@ -124,7 +124,7 @@ int main (int argc, char* argv[])
         // compute and output divergence, then copy into plofile
         EB_computeDivergence(divu, amrex::GetArrOfConstPtrs(vel), geom, false);
         amrex::Print() << "\nmax-norm of divu after projection is " << divu.norm0() << "\n" << std::endl;
-        plotfile_mf.copy(divu,0,2*AMREX_SPACEDIM+1,1);
+        plotfile_mf.ParallelCopy(divu,0,2*AMREX_SPACEDIM+1,1);
 
         EB_WriteSingleLevelPlotfile("plt", plotfile_mf,
                                     {"before-vx", "before-vy",

--- a/GPU/run.saul
+++ b/GPU/run.saul
@@ -1,0 +1,124 @@
+#!/bin/bash -l
+#SBATCH -C gpu
+#SBATCH -t 01:00:00 
+#SBATCH -J AMReX_CNS
+#SBATCH -o AMReX_CNS.o%j
+#SBATCH -A m1759 
+#SBATCH -N 4 
+#SBATCH -c 32 
+#SBATCH --ntasks-per-node=4
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=single:1
+
+# ============
+# -N =                 nodes
+# -n =                 tasks (MPI ranks, usually = G)
+# -G =                 GPUs (full Perlmutter node, 4)
+# -c =                 CPU per task (128 total threads on CPU, 32 per GPU)
+#
+# --ntasks-per-node=   number of tasks (MPI ranks) per node (full node, 4)
+# --gpus-per-task=     number of GPUs per task (MPI rank) (full node, 4)
+# --gpus-per-node=     number of GPUs per node (full node, 4)
+#
+# --gpu-bind=single:1  sets only one GPU to be visible to each MPI rank
+#                         (quiets AMReX init warnings)
+#
+# Recommend using --ntasks-per-node=4, --gpus-per-task=1 and --gpu-bind=single:1,
+# as they are fixed values and allow for easy scaling with less adjustments.
+#
+# ============
+# e.g.
+# For one node:  -N 1, -n 4, -c 32, --gpus-per-node=4, --ntasks-per-node=4
+# For two nodes: -N 2, -n 8, -c 32, --gpus-per-node=4, --ntasks-per-node=4
+
+# salloc commands:
+# ================
+# Single node:
+# salloc -N 1 --ntasks-per-node=4 -t 2:00:00 -C gpu -c 32 -G 4 -A m1759 
+# Multi node:
+# salloc -N 2 --ntasks-per-node=4 -t 2:00:00 -C gpu -c 32 -G 8 -A m1759
+
+EXE=../WarpX/build/bin/warpx.3d.MPI.CUDA.DP.OPMD.QED
+#EXE=./main3d.gnu.TPROF.MPI.CUDA.ex
+INPUTS=inputs_small
+
+# Basic job submissions:
+# =============================
+# Run inside the current salloc session using available resources.
+# Change parameters to match available resources & run with "./run.corigpu"
+# srun -n 16 --ntasks-per-node=4 --gpus-per-task=1 --gpu-bind=single:1 ${EXE} ${INPUTS}
+
+# Submit with the SBATCH configuration above to the gpu queue: "sbatch run.corigpu"
+# Can also be ran with "./run.corigpu" to run with 1 CPU and 1 GPU.
+srun ${EXE} ${INPUTS}
+
+
+
+
+
+# ==============================
+#  NEEDS TESTING AND ADJUSTMENT
+# ==============================
+
+# NSight Systems
+# ==============
+
+# @@ Simple Example:
+#srun nsys profile -o nsys_out.%q{SLURM_PROCID}.%q{SLURM_JOBID} ${EXE} ${INPUTS}
+
+# @@ Recommended Example:
+#srun nsys profile -c nvtx -p "<TINY_PROFILER_NAME>@*" -e NSYS_NVTX_PROFILER_REGISTER_ONLY=0 -o nsys_out.%q{SLURM_PROCID}.%q{SLURM_JOBID} ${EXE} ${INPUTS}
+
+# @@ Discussion:
+#   This will run nsys profile and store performance data in a qdrep file named after '-o'
+#   Open using nsight-sys $(pwd)/nsys_out.#.######.qdrep
+
+#   To capture the NVTX ranges, included in TINY_PROFILE objects, use:
+#       "-e NSYS_NVTX_PROFILER_REGISTER_ONLY=0"
+#   (TINY_PROFILE's NVTX regions do not use registered strings at this time.)
+
+#   Nsight systems creates a timeline over a single, contiguous block of time.
+#   The start of the timeline can be selected using TINY_PROFILER's NVTX markers with:
+#     -c nvtx -p "region_name@*"
+#   This will turn on the profiling analysis at the first instance of the TINY_PROFILER region
+#   and run to the end of the program. To stop the analysis at the end of the same region, add:
+#     -x true
+#   Note: This will only analyze the first instance of the region, so "-x true" should be used
+#   for specific analyses, or on more inclusive timers, e.g. a timer around a full timestep.
+
+# @@ Documentation:
+#   For NSight System profiling flags:
+#      https://docs.nvidia.com/nsight-systems/profiling/index.html#cli-profile-command-switch-options
+#   For NSight examples to launch profiling, including region limiting:
+#      https://docs.nvidia.com/nsight-systems/profiling/index.html#example-interactive-cli-command-sequences
+
+# Running NSight Systems on multiple ranks
+# ========================================
+
+# Run Nsight Systems only profiling on $PROFILE_RANK rank on a multi-rank job
+#    **** Preferred for most basic use cases
+#srun ./profile_1rank.sh ${EXE} ${INPUTS}
+
+# Uncomment and copy the following lines into profile_1rank.sh
+# Adjust the nsys command line as needed for your test case.
+# #!/bin/bash
+# PROFILE_RANK=0
+# if [ $SLURM_PROCID == $PROFILE_RANK ]; then
+#   nsys profile -o nsys_out.%q{SLURM_PROCID}.%q{SLURM_JOBID} "$@"
+# else
+#   "$@"
+# fi
+
+# NSight Compute
+# ==============
+
+# Run Nsight Compute:
+#    **** This will do a A LOT of analysis. Unless you want the entire job ran 7 times
+#    **** with full profiling, limit the kernels profiled with additional flags:
+#    For filtering examples, see:
+#    https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#nvtx-filtering
+#    For full list of profile options, see:
+#    https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#command-line-options-profile
+#    Recommended: limit kernels tested within a given BL_PROFILER timer with "--nvtx-include <configuration>"
+#      Note: Must use TINY_PROFILE=TRUE and nvtx region names are equal to BL_PROFILER timer names.
+#srun nv-nsight-cu-cli -o cucli_out.%q{SLURM_PROCID}.%q{SLURM_JOBID} ${EXE} ${INPUTS}

--- a/LinearSolvers/ABecLaplacian_F/mytest.F90
+++ b/LinearSolvers/ABecLaplacian_F/mytest.F90
@@ -151,7 +151,7 @@ contains
 
 
   subroutine finalize ()
-    integer :: ilev, idim
+    integer :: ilev
     do ilev = 0, max_level
        call amrex_geometry_destroy(geom(ilev))
        call amrex_boxarray_destroy(ba(ilev))

--- a/Particles/ElectrostaticPIC/ElectrostaticParticleContainer.cpp
+++ b/Particles/ElectrostaticPIC/ElectrostaticParticleContainer.cpp
@@ -109,7 +109,7 @@ ElectrostaticParticleContainer::DepositCharge(ScalarMeshData& rho) {
                                    (*rho[lev+1])[mfi].dataPtr(), fine_box.loVect(), fine_box.hiVect());
         }
 
-        rho[lev]->copy(coarsened_fine_data, m_gdb->Geom(lev).periodicity(), FabArrayBase::ADD);
+        rho[lev]->ParallelCopy(coarsened_fine_data, m_gdb->Geom(lev).periodicity(), FabArrayBase::ADD);
     }
 
     for (int lev = 0; lev < num_levels; ++lev) {
@@ -189,10 +189,10 @@ FieldGather(const VectorMeshData& E,
     MultiFab coarse_Ez(coarsened_fine_BA, fine_dm, 1, 1);
 #endif
 
-    coarse_Ex.copy(*E[0][0], 0, 0, 1, 1, 1);
-    coarse_Ey.copy(*E[0][1], 0, 0, 1, 1, 1);
+    coarse_Ex.ParallelCopy(*E[0][0], 0, 0, 1, 1, 1);
+    coarse_Ey.ParallelCopy(*E[0][1], 0, 0, 1, 1, 1);
 #if BL_SPACEDIM == 3
-    coarse_Ez.copy(*E[0][2], 0, 0, 1, 1, 1);
+    coarse_Ez.ParallelCopy(*E[0][2], 0, 0, 1, 1, 1);
 #endif
 
     for (int lev = 0; lev < num_levels; ++lev) {

--- a/Particles/ElectrostaticPIC/main.cpp
+++ b/Particles/ElectrostaticPIC/main.cpp
@@ -148,7 +148,7 @@ void sumFineToCrseNodal(const MultiFab& fine, MultiFab& crse,
                                fine[mfi].dataPtr(), fine_box.loVect(), fine_box.hiVect());
     }
 
-    crse.copy(coarsened_fine_data, cgeom.periodicity(), FabArrayBase::ADD);
+    crse.ParallelCopy(coarsened_fine_data, cgeom.periodicity(), FabArrayBase::ADD);
 }
 
 void fixRHSForSolve(Vector<std::unique_ptr<MultiFab> >& rhs,


### PR DESCRIPTION
First draft, used for running WarpX at the dedication.

Only real noticeable difference from other systems for now is:
`#SBATCH --gpu-bind=single:1`
to bind a single GPU to each rank. This eliminates warnings given during initialization.

No profiling has been done yet, so left Corigpu instructions to remember to update those.