### PR TITLE
Due to some change in the runner environment, we need the tex-gyre package now.

### DIFF
--- a/.github/workflows/dependencies/documentation.sh
+++ b/.github/workflows/dependencies/documentation.sh
@@ -16,5 +16,6 @@ sudo apt-get install -y --no-install-recommends\
     texlive \
     texlive-latex-extra \
     texlive-lang-cjk \
+    tex-gyre \
     latexmk
 


### PR DESCRIPTION
This should fix the CI failures with the docs build.