### PR TITLE
Update default AMREX_HOME for all tutorials

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -15,12 +15,10 @@ set -eu -o pipefail
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
 wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key \
   | sudo apt-key add -
-#echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' \
-# Use 4.1.1 till the VOP bug in 4.2 is fixed
-echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.1.1/ xenial main' \
+echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 
-echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin' \
+echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
@@ -36,12 +34,14 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev rocrand rocprim
+    rocm-dev roctracer-dev rocprofiler-dev rocrand rocprim
 
 # activate
 #
 source /etc/profile.d/rocm.sh
 hipcc --version
+which clang
+which clang++
 
 # cmake-easyinstall
 #

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -244,15 +244,16 @@ jobs:
         cd build
         cmake ..                                           \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_LINEAR_SOLVERS=ON     \
-            -DAMReX_FORTRAN=ON          \
-            -DAMReX_FORTRAN_INTERFACES=ON \
-            -DAMReX_EB=ON                 \
-            -DAMReX_PARTICLES=ON                          \
-            -DAMReX_FORTRAN=ON                            \
-            -DAMReX_LINEAR_SOLVERS=ON                     \
-            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_LINEAR_SOLVERS=ON                      \
+            -DAMReX_FORTRAN=ON                             \
+            -DAMReX_FORTRAN_INTERFACES=ON                  \
+            -DAMReX_EB=ON                                  \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_FORTRAN=ON                             \
+            -DAMReX_LINEAR_SOLVERS=ON                      \
+            -DAMReX_GPU_BACKEND=HIP                        \
             -DAMReX_AMD_ARCH=gfx900                        \
+            -DCMAKE_CXX_STANDARD=17                        \
             -DCMAKE_C_COMPILER=$(which clang)              \
             -DCMAKE_CXX_COMPILER=$(which hipcc)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -231,7 +231,17 @@ jobs:
   tutorials-hip:
     name: HIP ROCm GFortran@9.3 C++17 [tutorials]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names"}
+    # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
+    # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
+    #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
+    #        __launch_bounds__(amrex_launch_bounds_max_threads)
+    #        ^
+    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
+    #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
+    #                                                                          ^
+    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
+    #    #define select_impl_(_1, _2, impl_, ...) impl_
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-pass-failed"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -242,20 +252,23 @@ jobs:
         hipcc --version
         which clang
         which clang++
-        mkdir build
-        cd build
-        cmake ..                                           \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_LINEAR_SOLVERS=ON                      \
-            -DAMReX_FORTRAN=OFF                            \
-            -DAMReX_FORTRAN_INTERFACES=OFF                 \
-            -DAMReX_EB=ON                                  \
-            -DAMReX_PARTICLES=ON                           \
-            -DAMReX_GPU_BACKEND=HIP                        \
-            -DAMReX_AMD_ARCH=gfx900                        \
-            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
-            -DCMAKE_CXX_STANDARD=17                        \
-            -DCMAKE_C_COMPILER=$(which clang)              \
-            -DCMAKE_CXX_COMPILER=$(which clang++)          \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)
-        make -j 2
+
+        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
+        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
+        #   https://github.com/open-mpi/ompi/issues/9317
+        export LDFLAGS="-lopen-pal"
+
+        cmake -S . -B build_nofortran                     \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
+            -DAMReX_EB=ON                                 \
+            -DAMReX_ENABLE_TESTS=ON                       \
+            -DAMReX_PARTICLES=ON                          \
+            -DAMReX_FORTRAN=OFF                           \
+            -DAMReX_LINEAR_SOLVERS=ON                     \
+            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
+            -DCMAKE_C_COMPILER=$(which clang)             \
+            -DCMAKE_CXX_COMPILER=$(which clang++)         \
+            -DCMAKE_CXX_STANDARD=17
+        cmake --build build_nofortran -j 2
+

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,7 +250,6 @@ jobs:
             -DAMReX_EB=ON                                  \
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=HIP                        \
-
             -DAMReX_AMD_ARCH=gfx900                        \
             -DCMAKE_CXX_STANDARD=17                        \
             -DCMAKE_C_COMPILER=$(which clang)              \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -251,6 +251,7 @@ jobs:
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=HIP                        \
             -DAMReX_AMD_ARCH=gfx900                        \
+            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
             -DCMAKE_CXX_STANDARD=17                        \
             -DCMAKE_C_COMPILER=$(which clang)              \
             -DCMAKE_CXX_COMPILER=$(which hipcc)            \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -254,6 +254,6 @@ jobs:
             -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
             -DCMAKE_CXX_STANDARD=17                        \
             -DCMAKE_C_COMPILER=$(which clang)              \
-            -DCMAKE_CXX_COMPILER=$(which hipcc)            \
+            -DCMAKE_CXX_COMPILER=$(which clang++)          \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         make -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -240,6 +240,8 @@ jobs:
       run: |
         source /etc/profile.d/rocm.sh
         hipcc --version
+        which clang
+        which clang++
         mkdir build
         cd build
         cmake ..                                           \

--- a/Blueprint/AssignMultiLevelDensity/GNUmakefile
+++ b/Blueprint/AssignMultiLevelDensity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 #
 # This example requires installs of:

--- a/Blueprint/CellSortedParticles/GNUmakefile
+++ b/Blueprint/CellSortedParticles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Blueprint/HeatEquation_EX1_C/Exec/GNUmakefile
+++ b/Blueprint/HeatEquation_EX1_C/Exec/GNUmakefile
@@ -1,5 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-AMREX_HOME = ../../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 #
 # This example requires installs of:

--- a/EB/CNS/Exec/Make.CNS
+++ b/EB/CNS/Exec/Make.CNS
@@ -1,4 +1,4 @@
-AMREX_HOME := ../../../../../amrex
+AMREX_HOME ?= ../../../../../amrex
 TOP := ../../
 
 EBASE := CNS

--- a/EB/GeometryGeneration/GNUmakefile
+++ b/EB/GeometryGeneration/GNUmakefile
@@ -11,7 +11,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/EB/MacProj/GNUmakefile
+++ b/EB/MacProj/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/EB/Poisson/GNUmakefile
+++ b/EB/Poisson/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/EB/STLtest/GNUmakefile
+++ b/EB/STLtest/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 DEBUG	= FALSE
 

--- a/ForkJoin/MLMG/GNUmakefile
+++ b/ForkJoin/MLMG/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 DEBUG ?= TRUE
 DIM ?= 2

--- a/ForkJoin/Simple/GNUmakefile
+++ b/ForkJoin/Simple/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 DEBUG ?= FALSE
 DIM ?= 3

--- a/GPU/CNS/Exec/Make.CNS
+++ b/GPU/CNS/Exec/Make.CNS
@@ -1,4 +1,4 @@
-AMREX_HOME := ../../../../../amrex
+AMREX_HOME ?= ../../../../../amrex
 TOP := ../../../CNS
 
 EBASE := CNS

--- a/LinearSolvers/ABecLaplacian_C/GNUmakefile
+++ b/LinearSolvers/ABecLaplacian_C/GNUmakefile
@@ -10,7 +10,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/LinearSolvers/ABecLaplacian_F/GNUmakefile
+++ b/LinearSolvers/ABecLaplacian_F/GNUmakefile
@@ -8,7 +8,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/LinearSolvers/MAC_Projection_EB/GNUmakefile
+++ b/LinearSolvers/MAC_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 USE_EB = TRUE
 

--- a/LinearSolvers/MultiComponent/GNUmakefile
+++ b/LinearSolvers/MultiComponent/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 DEBUG	?= FALSE
 DIM	?= 3

--- a/LinearSolvers/NodalPoisson/GNUmakefile
+++ b/LinearSolvers/NodalPoisson/GNUmakefile
@@ -7,7 +7,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/LinearSolvers/Nodal_Projection_EB/GNUmakefile
+++ b/LinearSolvers/Nodal_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 USE_EB = TRUE
 

--- a/LinearSolvers/NodeTensorLap/GNUmakefile
+++ b/LinearSolvers/NodeTensorLap/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/MUI/Exec_01/GNUmakefile
+++ b/MUI/Exec_01/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/MUI/Exec_02/GNUmakefile
+++ b/MUI/Exec_02/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME = ../../../amrex
+AMREX_HOME ?= ../../../amrex
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/Particles/ElectromagneticPIC/Exec/CUDA/GNUmakefile
+++ b/Particles/ElectromagneticPIC/Exec/CUDA/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../../../amrex
+AMREX_HOME ?= ../../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Particles/ElectromagneticPIC/Exec/OpenACC/GNUmakefile
+++ b/Particles/ElectromagneticPIC/Exec/OpenACC/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../../../amrex
+AMREX_HOME ?= ../../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Particles/ElectromagneticPIC/Exec/OpenMP/GNUmakefile
+++ b/Particles/ElectromagneticPIC/Exec/OpenMP/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../../../amrex
+AMREX_HOME ?= ../../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Particles/NeighborList/MDParticleContainer.cpp
+++ b/Particles/NeighborList/MDParticleContainer.cpp
@@ -106,7 +106,6 @@ void MDParticleContainer::computeForces()
     BL_PROFILE("MDParticleContainer::computeForces");
 
     const int lev = 0;
-    const Geometry& geom = Geom(lev);
     auto& plev  = GetParticles(lev);
 
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
@@ -157,7 +156,6 @@ Real MDParticleContainer::minDistance()
     BL_PROFILE("MDParticleContainer::minDistance");
 
     const int lev = 0;
-    const Geometry& geom = Geom(lev);
     auto& plev  = GetParticles(lev);
 
     Real min_d = std::numeric_limits<Real>::max();
@@ -210,10 +208,8 @@ void MDParticleContainer::moveParticles(const amrex::Real& dt)
     BL_PROFILE("MDParticleContainer::moveParticles");
 
     const int lev = 0;
-    const Geometry& geom = Geom(lev);
     const auto plo = Geom(lev).ProbLoArray();
     const auto phi = Geom(lev).ProbHiArray();
-    const auto dx = Geom(lev).CellSizeArray();
     auto& plev  = GetParticles(lev);
 
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)

--- a/SDC/MISDC_ADR_2d/Exec/GNUmakefile
+++ b/SDC/MISDC_ADR_2d/Exec/GNUmakefile
@@ -1,5 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-AMREX_HOME = ../../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
+++ b/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../../..
+AMREX_HOME ?= ../../../../../amrex
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
+++ b/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME = ../../../../..
+AMREX_HOME ?= ../../../../../amrex
 
 USE_EB = FALSE
 PRECISION  = DOUBLE


### PR DESCRIPTION
By default, AMREX_HOME for all tutorials should assume the repo has been checked out alongside amrex. Should not override if already set.