### PR TITLE
Update: SetupCUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,14 +43,17 @@ if( NOT DEFINED AMReX_DIR )
        # available to the entire project
        include(AMReXOptions)
 
-       if (AMReX_FORTRAN)
+       if(AMReX_FORTRAN)
           enable_language(Fortran)
        endif ()
 
-       if (AMReX_GPU_BACKEND STREQUAL "CUDA")
+       if(AMReX_GPU_BACKEND STREQUAL "CUDA")
           enable_language(CUDA)
-          include(AMReX_SetupCUDA)
-       endif ()
+          # AMReX 21.06+ supports CUDA_ARCHITECTURES
+          if(CMAKE_VERSION VERSION_LESS 3.20)
+             include(AMReX_SetupCUDA)
+          endif()
+       endif()
 
        # Bring the populated content into the build
        add_subdirectory(${amrex_SOURCE_DIR} ${amrex_BINARY_DIR})
@@ -61,9 +64,12 @@ else()
    enable_language(Fortran)
    find_package(AMReX REQUIRED)
 
-   if (AMReX_GPU_BACKEND STREQUAL "CUDA")
+   if(AMReX_GPU_BACKEND STREQUAL "CUDA")
       enable_language(CUDA)
-      include(AMReX_SetupCUDA)
+      # AMReX 21.06+ supports CUDA_ARCHITECTURES
+      if(CMAKE_VERSION VERSION_LESS 3.20)
+         include(AMReX_SetupCUDA)
+      endif()
    endif()
 endif()
 


### PR DESCRIPTION
Only needed for older CMake versions.

Refs.:
- https://github.com/AMReX-Codes/amrex/pull/2012 (feature added to AMReX 21.06+)
- https://github.com/AMReX-Codes/amrex/pull/2074 (regression currently in review, needs to be merged; update: merged)
- https://github.com/Hi-PACE/hipace/pull/522 (same logic for HiPACE++)
- https://github.com/AMReX-Codes/amrex/pull/2076 (just a regression on the way)
- https://github.com/AMReX-Codes/amrex/pull/2077 filter out unsupported SMs, e.g. if we fall back to heuristics
- https://github.com/ECP-WarpX/WarpX/pull/1998