### PR TITLE
Fix: CMake Module Collision (Fortran)

### DIFF
--- a/cmake/SetupTutorials.cmake
+++ b/cmake/SetupTutorials.cmake
@@ -42,11 +42,11 @@ function (setup_tutorial _srcs  _inputs)
    if (_HAS_FORTRAN_MODULES)
       target_include_directories(${_exe_name}
          PRIVATE
-         ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files)
+         ${CMAKE_CURRENT_BINARY_DIR}/${_exe_name}_mod_files)
       set_target_properties( ${_exe_name}
          PROPERTIES
          Fortran_MODULE_DIRECTORY
-         ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files )
+         ${CMAKE_CURRENT_BINARY_DIR}/${_exe_name}_mod_files )
    endif ()
 
    target_link_libraries( ${_exe_name} AMReX::amrex )


### PR DESCRIPTION
Fix a race conditions in module creation for some tutorials. Make the Fortran module directory unique by the executable name.

This looks like the `EXENAME` variable was forgotten to be renamed during refactoring. The current local name for the exe is `_exe_name`. (Undefined vars are empty. There should potentially also be a `-Wdev` error been thrown at configure time.)


Fix #27
Same as https://github.com/AMReX-Codes/amrex/pull/1112