### PR TITLE
Correct typo in AmrCore tutorial.

### DIFF
--- a/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
+++ b/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
@@ -39,7 +39,7 @@ AmrCoreAdv::DefineVelocityAtLevel (int lev, Real time)
                                                                       facevel[lev][2].array(mfi)) };
 
             const Box& psibox = Box(IntVect(AMREX_D_DECL(std::min(ngbxx.smallEnd(0)-1, ngbxy.smallEnd(0)-1),
-                                                         std::min(ngbxx.smallEnd(1)-1, ngbxy.smallEnd(0)-1),
+                                                         std::min(ngbxx.smallEnd(1)-1, ngbxy.smallEnd(1)-1),
                                                          0)),
                                     IntVect(AMREX_D_DECL(std::max(ngbxx.bigEnd(0),   ngbxy.bigEnd(0)+1),
                                                          std::max(ngbxx.bigEnd(1)+1, ngbxy.bigEnd(1)),


### PR DESCRIPTION
In the AmrCore tutorial, for the file `DefineVelocity.cpp` fix typo on line 42. See issue #33.