### PR TITLE
Force turning off particle tiling for GPU on Advection_AmrLevel tutorial

### DIFF
--- a/Amr/Advection_AmrLevel/Source/main.cpp
+++ b/Amr/Advection_AmrLevel/Source/main.cpp
@@ -24,6 +24,14 @@ main (int   argc,
     Real strt_time;
     Real stop_time;
 
+    // force particle tiling to be off for GPU
+#ifdef AMREX_USE_GPU
+    {
+        ParmParse pp("particles");
+        pp.add("do_tiling", 0);
+    }
+#endif
+
     {
         ParmParse pp;
 


### PR DESCRIPTION
This enables the same inputs file to be used for GPU / non-GPU runs.