### PR TITLE
Fix compilation with GNU make for some ExampleCodes.

### DIFF
--- a/ExampleCodes/Basic/HeatEquation_EX1_F/GNUmakefile
+++ b/ExampleCodes/Basic/HeatEquation_EX1_F/GNUmakefile
@@ -1,5 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG     = TRUE
 

--- a/ExampleCodes/Basic/HelloWorld_C/GNUmakefile
+++ b/ExampleCodes/Basic/HelloWorld_C/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/ExampleCodes/Basic/HelloWorld_F/GNUmakefile
+++ b/ExampleCodes/Basic/HelloWorld_F/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/ExampleCodes/Basic/main_C/GNUmakefile
+++ b/ExampleCodes/Basic/main_C/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/ExampleCodes/Basic/main_F/GNUmakefile
+++ b/ExampleCodes/Basic/main_F/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/ExampleCodes/Blueprint/AssignMultiLevelDensity/GNUmakefile
+++ b/ExampleCodes/Blueprint/AssignMultiLevelDensity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 #
 # This example requires installs of:

--- a/ExampleCodes/Blueprint/CellSortedParticles/GNUmakefile
+++ b/ExampleCodes/Blueprint/CellSortedParticles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/ExampleCodes/EB/GeometryGeneration/GNUmakefile
+++ b/ExampleCodes/EB/GeometryGeneration/GNUmakefile
@@ -11,7 +11,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/EB/MacProj/GNUmakefile
+++ b/ExampleCodes/EB/MacProj/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/EB/Poisson/GNUmakefile
+++ b/ExampleCodes/EB/Poisson/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/EB/STLtest/GNUmakefile
+++ b/ExampleCodes/EB/STLtest/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 

--- a/ExampleCodes/ForkJoin/MLMG/GNUmakefile
+++ b/ExampleCodes/ForkJoin/MLMG/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG ?= TRUE
 DIM ?= 2

--- a/ExampleCodes/ForkJoin/Simple/GNUmakefile
+++ b/ExampleCodes/ForkJoin/Simple/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG ?= FALSE
 DIM ?= 3

--- a/ExampleCodes/LinearSolvers/ABecLaplacian_C/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/ABecLaplacian_C/GNUmakefile
@@ -10,7 +10,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/LinearSolvers/ABecLaplacian_F/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/ABecLaplacian_F/GNUmakefile
@@ -8,7 +8,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/LinearSolvers/MAC_Projection_EB/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/MAC_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 USE_EB = TRUE
 

--- a/ExampleCodes/LinearSolvers/MultiComponent/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/MultiComponent/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	?= FALSE
 DIM	?= 3

--- a/ExampleCodes/LinearSolvers/NodalPoisson/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/NodalPoisson/GNUmakefile
@@ -7,7 +7,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/LinearSolvers/Nodal_Projection_EB/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/Nodal_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 USE_EB = TRUE
 

--- a/ExampleCodes/LinearSolvers/NodeTensorLap/GNUmakefile
+++ b/ExampleCodes/LinearSolvers/NodeTensorLap/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/ExampleCodes/MUI/Exec_01/GNUmakefile
+++ b/ExampleCodes/MUI/Exec_01/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/ExampleCodes/MUI/Exec_02/GNUmakefile
+++ b/ExampleCodes/MUI/Exec_02/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/ExampleCodes/Particles/CellSortedParticles/GNUmakefile
+++ b/ExampleCodes/Particles/CellSortedParticles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/ExampleCodes/Particles/ElectrostaticPIC/GNUmakefile
+++ b/ExampleCodes/Particles/ElectrostaticPIC/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/ExampleCodes/Particles/NeighborList/GNUmakefile
+++ b/ExampleCodes/Particles/NeighborList/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DEBUG	= FALSE
 

--- a/ExampleCodes/SWFFT/SWFFT_poisson/GNUmakefile
+++ b/ExampleCodes/SWFFT/SWFFT_poisson/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DIM = 3
 

--- a/ExampleCodes/SWFFT/SWFFT_simple/GNUmakefile
+++ b/ExampleCodes/SWFFT/SWFFT_simple/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME ?= ../../../../amrex
 
 DIM = 3
 


### PR DESCRIPTION
Recent reorganization (PR#22) broke the guess for AMREX_HOME. This
changes it to the directory containing amrex-tutorials.