### PR TITLE
Allow AmrLevel tutorials to compile with or without particles.

### DIFF
--- a/ExampleCodes/Amr/Advection_AmrLevel/Exec/Make.Adv
+++ b/ExampleCodes/Amr/Advection_AmrLevel/Exec/Make.Adv
@@ -16,7 +16,10 @@ include $(Bpack)
 INCLUDE_LOCATIONS += $(Blocs)
 VPATH_LOCATIONS   += $(Blocs)
 
-Pdirs 	:= Base Boundary AmrCore Amr Particle
+Pdirs 	:= Base Boundary AmrCore Amr
+ifeq ($(USE_PARTICLES),TRUE)
+    Pdirs += Particle
+endif
 Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 
 include $(Ppack)

--- a/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
+++ b/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
@@ -16,7 +16,8 @@ USE_PARTICLES = TRUE
 USE_MPI    = TRUE
 USE_OMP    = FALSE
 
-Bpack   := ./Make.package 
-Blocs   := . 
+Bpack   := ./Make.package
+Blocs   := .
 
 include ../Make.Adv
+

--- a/ExampleCodes/Amr/Advection_AmrLevel/Exec/UniformVelocity/GNUmakefile
+++ b/ExampleCodes/Amr/Advection_AmrLevel/Exec/UniformVelocity/GNUmakefile
@@ -11,8 +11,6 @@ DIM        = 2
 
 COMP	   = gnu
 
-#USE_PARTICLES = TRUE
-
 USE_MPI    = TRUE
 USE_OMP    = FALSE
 


### PR DESCRIPTION
This is needed after https://github.com/AMReX-Codes/amrex/pull/2703