### PR TITLE
ElectromagneticPIC: Tidy up the code and tweak error calculation

### DIFF
--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/Evolve.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/Evolve.cpp
@@ -128,8 +128,6 @@ void check_solution(const MultiFab& jx, const Geometry& geom, Real time)
 {
     BL_PROFILE("check_solution");
 
-    const Real* dx = geom.CellSize();
-
     Box test_box = geom.Domain();
     test_box.setSmall(IntVect(AMREX_D_DECL(2, 2, 2)));
     test_box.setBig(IntVect(AMREX_D_DECL(30, 30, 30)));

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/em_pic_K.H
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/em_pic_K.H
@@ -308,7 +308,7 @@ check_langmuir_solution (amrex::Box const& bx, amrex::Box const& test_box,
     amrex::Real error = 0.0;
 
     const amrex::Box b = bx & test_box;
-    amrex::Loop(bx, [=,&error] (int j, int k, int l) noexcept
+    amrex::Loop(b, [=,&error] (int j, int k, int l) noexcept
     {
         error = amrex::max(error, std::abs((jx(j,k,l) - j_exact) / j_exact));
     });

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
@@ -167,7 +167,7 @@ void test_em_pic(const TestParams& parms)
 
         if (parms.problem_type == Langmuir)
         {
-            check_solution(jx, geom, time);
+            check_solution(jx, geom, time - 0.5*dt);
         } else
         {
             amrex::Print() << "Not computing error - no exact solution" << std::endl;

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
@@ -34,22 +34,16 @@ void test_em_pic(const TestParams& parms)
 
     BL_PROFILE_VAR_START(blp_init);
 
-    RealBox real_box;
-    for (int n = 0; n < BL_SPACEDIM; n++)
-    {
-        real_box.setLo(n, -20e-6);
-        real_box.setHi(n,  20e-6);
-    }
+    RealBox real_box({AMREX_D_DECL(-20e-6, -20e-6, -20e-6)},
+                     {AMREX_D_DECL( 20e-6,  20e-6,  20e-6)});
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
     IntVect domain_hi(AMREX_D_DECL(parms.ncell[0]-1,parms.ncell[1]-1,parms.ncell[2]-1));
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
-    Geometry geom(domain, &real_box, coord, is_per);
+    IntArray is_periodic {AMREX_D_DECL(1,1,1)};
+    Geometry geom(domain, real_box, coord, is_periodic);
 
     BoxArray ba(domain);
     ba.maxSize(parms.max_grid_size);
@@ -82,19 +76,14 @@ void test_em_pic(const TestParams& parms)
     {
         num_species = 2;
 
-        RealBox electron_bounds = RealBox(AMREX_D_DECL(-20e-6, -20e-6, -20e-6),
-                                          AMREX_D_DECL( 20e-6, 20e-6, 20e-6));
         EMParticleContainer* electrons;
-        electrons = new EMParticleContainer(geom, dm, ba,
-                                                         0, -PhysConst::q_e, PhysConst::m_e);
-        electrons->InitParticles(parms.nppc, 0.01, 10.0, 1e25, electron_bounds, parms.problem_type);
-
-        RealBox H_ions_bounds = RealBox(AMREX_D_DECL(-20e-6, -20e-6, -20e-6),
-                                        AMREX_D_DECL( 20e-6,  20e-6,  20e-6));
         EMParticleContainer* H_ions;
-        H_ions = new EMParticleContainer(geom, dm, ba,
-                                                      1, PhysConst::q_e, PhysConst::m_p);
-        H_ions->InitParticles(parms.nppc, 0.01, 10.0, 1e25, H_ions_bounds, parms.problem_type);
+
+        electrons = new EMParticleContainer(geom, dm, ba, 0, -PhysConst::q_e, PhysConst::m_e);
+        H_ions    = new EMParticleContainer(geom, dm, ba, 1,  PhysConst::q_e, PhysConst::m_p);
+
+        electrons->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
+        H_ions   ->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
 
         particles[0].reset(electrons);
         particles[1].reset(H_ions);
@@ -103,12 +92,11 @@ void test_em_pic(const TestParams& parms)
     {
         num_species = 1;
 
-        RealBox electron_bounds = RealBox(AMREX_D_DECL(-20e-6, -20e-6, -20e-6),
-                                          AMREX_D_DECL( 0.0,    20e-6,  20e-6));
         EMParticleContainer* electrons;
-        electrons = new EMParticleContainer(geom, dm, ba,
-                                                         0, -PhysConst::q_e, PhysConst::m_e);
-        electrons->InitParticles(parms.nppc, 0.01, 10.0, 1e25, electron_bounds, parms.problem_type);
+
+        electrons = new EMParticleContainer(geom, dm, ba, 0, -PhysConst::q_e, PhysConst::m_e);
+
+        electrons->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
 
         particles[0].reset(electrons);
     }

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
@@ -164,19 +164,19 @@ void test_em_pic(const TestParams& parms)
         }
 
         time += dt;
+
+        if (parms.problem_type == Langmuir)
+        {
+            check_solution(jx, geom, time);
+        } else
+        {
+            amrex::Print() << "Not computing error - no exact solution" << std::endl;
+        }
     }
 
     amrex::Print() << "Done. " << std::endl;
 
     BL_PROFILE_VAR_STOP(blp_evolve);
-
-    if (parms.problem_type == Langmuir)
-    {
-        check_solution(jx, geom, time);
-    } else
-    {
-        amrex::Print() << "Not computing error - no exact solution" << std::endl;
-    }
 
     if (parms.write_plot)
     {


### PR DESCRIPTION
Hi,

Due to the oscillating nature of the solution, the numerical error follows a similar trend.
Thus, since the error is not monotonic, I thought it'd make sense to print it at every iteration and not just at the end.
The other commits should be self-explanatory.

Cheers,
Nuno