### PR TITLE
GitHub workflows: fixes and tweaks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -135,38 +135,6 @@ jobs:
             -DAMReX_FORTRAN=OFF
         make -j 2
 
-  # Build all tutorials with CUDA 10.2
-  tutorials-cuda10:
-    name: CUDA@10.2 GNU@6.5.0 C++14 Release [tutorials]
-    runs-on: ubuntu-18.04
-    env: {CXXFLAGS: "-fno-operator-names"}
-    steps:
-    - uses: actions/checkout@v3
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc10.sh
-    - name: Build & Install
-      run: |
-        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
-        which nvcc || echo "nvcc not in PATH!"
-        cd ExampleCodes
-        mkdir build
-        cd build
-        cmake ..                                           \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_LINEAR_SOLVERS=ON     \
-            -DAMReX_FORTRAN=ON          \
-            -DAMReX_FORTRAN_INTERFACES=ON \
-            -DAMReX_PARTICLES=ON                           \
-            -DAMReX_GPU_BACKEND=CUDA                       \
-            -DCMAKE_C_COMPILER=$(which gcc-6)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
-            -DAMReX_CUDA_ARCH=7.0 \
-            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
-        make -j 2
-
   # Build all tutorials with CUDA 11.0.2 (recent supported)
   tutorials-cuda11:
     name: CUDA@11.2 GNU@9.3.0 C++17 Release [tutorials]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
 
   # Build all tutorials
   tutorials_cxx20:
-    name: GNU@10.1 C++20 OMP [tutorials]
+    name: GNU@10.3 C++20 OMP [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,6 +16,8 @@ jobs:
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Build & Install
       run: |
+        export LIBRARY_PATH=/usr/local/opt/gcc/lib/gcc/current
+
         cd ExampleCodes
         cmake -S . -B build             \
             -DBUILD_SHARED_LIBS=ON      \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   # Build all tutorials
   tests-macos:
-    name: AppleClang@11.0 GFortran@9.3 [tutorials]
+    name: AppleClang@14.0 GFortran@12.2 [tutorials]
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Hi @WeiqunZhang,

I think the only ugly quirk here is the `LIBRARY_PATH` fix on macOS.
I've investigated this one quite a bit and can't for the life of me find the culprit, maybe someone else already did?

The error:
`ld: file not found: @rpath/libquadmath.0.dylib for architecture x86_64`

The libraries that we link against (directly, i.e. explicitly) when the error pops up and that depend on symbols from `libquadmath.0.dylib`  are: `libamrex.dylib`, `libmpi_usempif08.dylib` and `libmpi_usempi_ignore_tkr.dylib`.

But using `otool`, I can see that, for all of those, the links seem good...:
```
Load command 18
          cmd LC_LOAD_DYLIB
      cmdsize 80
         name /usr/local/opt/gcc/lib/gcc/current/libquadmath.0.dylib (offset 24)
   time stamp 2 Thu Jan  1 00:00:02 1970
      current version 1.0.0
compatibility version 1.0.0
```

So then I thought the problem might've come up via some indirect library dependence...
I tried changing the workflow to use macOS 11, cmake 3.24.0, Xcode 13 and gcc 11, all to no avail, unless I haven't tried the magic combination of those that works...
The puzzling thing is how it stopped working with no apparent culprit either in the tutorials or AMReX itself...

Cheers,
-Nuno