### PR TITLE
ElectromagneticPIC: Add the option to write particle positions to file

### DIFF
--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/inputs
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/inputs
@@ -12,3 +12,4 @@ nsteps = 10
 cfl = 1.0
 
 write_plot = false
+write_particles = false

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenACC/inputs
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenACC/inputs
@@ -12,3 +12,4 @@ nsteps = 10
 cfl = 1.0
 
 write_plot = false
+write_particles = false

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenMP/inputs
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenMP/inputs
@@ -12,3 +12,4 @@ nsteps = 10
 cfl = 1.0
 
 write_plot = false
+write_particles = false

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp
@@ -171,7 +171,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
                     z >= a_bounds.hi(2) || z < a_bounds.lo(2) ) continue;
 
                 ParticleType& p = pstruct[pidx];
-                p.id()   = 0;
+                p.id()   = pidx + 1;
                 p.cpu()  = procID;
                 p.pos(0) = x;
                 p.pos(1) = y;

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/IO.H
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/IO.H
@@ -5,10 +5,15 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 
+#include "EMParticleContainer.H"
+
 void
 WritePlotFile (const amrex::MultiFab& Ex, const amrex::MultiFab& Ey, const amrex::MultiFab& Ez,
                const amrex::MultiFab& Bx, const amrex::MultiFab& By, const amrex::MultiFab& Bz,
                const amrex::MultiFab& jx, const amrex::MultiFab& jy, const amrex::MultiFab& jz,
                const amrex::Geometry& geom, amrex::Real time, int step);
+
+void
+WriteParticleFile (const EMParticleContainer& PC, const std::string& name, int step);
 
 #endif

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/IO.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/IO.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_PlotFileUtil.H>
 
 #include "IO.H"
+#include "EMParticleContainer.H"
 
 using namespace amrex;
 
@@ -60,4 +61,17 @@ WritePlotFile (const MultiFab& Ex, const MultiFab& Ey, const MultiFab& Ez,
     dcomp += 3;
 
     amrex::WriteSingleLevelPlotfile(plotfilename, mf, varnames, geom, time, step);
+}
+
+void
+WriteParticleFile (const EMParticleContainer& PC, const std::string& name, int step)
+{
+    BL_PROFILE("WriteParticleFile()");
+
+    Vector<int> real_comp_mask(PIdx::nattribs, 0);
+    Vector<int> int_comp_mask{};
+
+    const std::string& plotdirectory = Concatenate("plt", step);
+
+    PC.WritePlotFile(plotdirectory, name, real_comp_mask, int_comp_mask);
 }

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
@@ -184,9 +184,9 @@ void test_em_pic(const TestParams& parms)
 
     if (parms.write_plot)
     {
-        WritePlotFile(Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, geom, time, nsteps);
         if (parms.write_particles)
         {
+            WritePlotFile(Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, geom, nsteps, nsteps);
             if (parms.problem_type == UniformPlasma)
             {
                 WriteParticleFile(*particles[0], "electrons", nsteps);
@@ -196,6 +196,10 @@ void test_em_pic(const TestParams& parms)
             {
                 WriteParticleFile(*particles[0], "electrons", nsteps);
             }
+        }
+        else
+        {
+            WritePlotFile(Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, geom, time, nsteps);
         }
     }
 }

--- a/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Source/main.cpp
@@ -21,6 +21,7 @@ struct TestParams
     int problem_type;
     Real cfl;
     bool write_plot;
+    bool write_particles;
 };
 
 enum ProblemType {UniformPlasma = 0, Langmuir};
@@ -78,16 +79,16 @@ void test_em_pic(const TestParams& parms)
         num_species = 2;
 
         EMParticleContainer* electrons;
-        EMParticleContainer* H_ions;
+        EMParticleContainer* protons;
 
         electrons = new EMParticleContainer(geom, dm, ba, 0, -PhysConst::q_e, PhysConst::m_e);
-        H_ions    = new EMParticleContainer(geom, dm, ba, 1,  PhysConst::q_e, PhysConst::m_p);
+        protons   = new EMParticleContainer(geom, dm, ba, 1,  PhysConst::q_e, PhysConst::m_p);
 
         electrons->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
-        H_ions   ->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
+        protons  ->InitParticles(parms.nppc, 0.01, 10.0, 1e25, real_box, parms.problem_type);
 
         particles[0].reset(electrons);
-        particles[1].reset(H_ions);
+        particles[1].reset(protons);
     }
     else if (parms.problem_type == Langmuir)
     {
@@ -184,6 +185,18 @@ void test_em_pic(const TestParams& parms)
     if (parms.write_plot)
     {
         WritePlotFile(Ex, Ey, Ez, Bx, By, Bz, jx, jy, jz, geom, time, nsteps);
+        if (parms.write_particles)
+        {
+            if (parms.problem_type == UniformPlasma)
+            {
+                WriteParticleFile(*particles[0], "electrons", nsteps);
+                WriteParticleFile(*particles[1], "protons",   nsteps);
+            }
+            else if (parms.problem_type == Langmuir)
+            {
+                WriteParticleFile(*particles[0], "electrons", nsteps);
+            }
+        }
     }
 }
 
@@ -203,6 +216,7 @@ int main(int argc, char* argv[])
     pp.get("max_grid_size", parms.max_grid_size);
     pp.get("nsteps", parms.nsteps);
     pp.get("write_plot", parms.write_plot);
+    pp.get("write_particles", parms.write_particles);
     pp.get("cfl", parms.cfl);
 
     std::string problem_name;


### PR DESCRIPTION
Hi @atmyers, @WeiqunZhang,

I think I may need some help here.
Initially, my objective was to reproduce the documentation [here](https://amrex-codes.github.io/amrex/docs_html/Visualization.html#visualizing-particle-data), but I couldn't.
In addition to `WriteAsciiFile` which I finally opted for, I also tried `WritePlotFile` which as far as I understand will output a file readable by `yt`.
I was able to convert both to `vtp` using the Python utility provided, but I don't think I have the option to preserve time information with either format? I think the problem is I can't get to use "AMReX/BoxLib Particles Reader" in Paraview which I believe is what I should be aiming for?

Thanks for your help,
Nuno
