### PR TITLE
Fix the ElectrostaticPIC example to work with multiple grids.

### DIFF
--- a/ExampleCodes/Particles/ElectrostaticPIC/src/field_solver/FieldSolver.cpp
+++ b/ExampleCodes/Particles/ElectrostaticPIC/src/field_solver/FieldSolver.cpp
@@ -125,7 +125,7 @@ void sumFineToCrseNodal (const MultiFab& fine, MultiFab& crse,
         const Box& bx = mfi.validbox();
         auto crse_data = coarsened_fine_data[mfi].array();
         const auto fine_data = fine[mfi].array();
-	const auto mskfab = mask->const_array(mfi);
+    const auto mskfab = mask->const_array(mfi);
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                                    if (mskfab(i,j,k)) {
                                        sum_fine_to_crse_nodal(i, j, k, crse_data, fine_data, ratio);

--- a/ExampleCodes/Particles/ElectrostaticPIC/src/particles/ElectrostaticParticleContainer.cpp
+++ b/ExampleCodes/Particles/ElectrostaticPIC/src/particles/ElectrostaticParticleContainer.cpp
@@ -68,7 +68,7 @@ ElectrostaticParticleContainer::DepositCharge (const Vector<MultiFab*>& rho) {
                                    });
         }
 
-        rho[lev]->SumBoundary(gm.periodicity());
+        rho[lev]->SumBoundary(0, 1, IntVect(1), gm.periodicity());
     }
 
     // now we average down fine to crse


### PR DESCRIPTION
Fix the ElectrostaticPIC example to work with multiple grids.
-Implement a mask for sumFineToCrseNodal so we don't double-add on shared fine boundary nodes when averaging to coarse
-Ensure sumboundary also updates the fine ghost cells since those are needed in the coarsening stencil
Thanks Weiqun for the fix!