### PR TITLE
CI: oneAPI Apt Update

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -9,16 +9,19 @@ set -eu -o pipefail
 
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
-wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
-  | sudo apt-key add -
-echo "deb https://apt.repos.intel.com/oneapi all main" \
-  | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository:
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential \
-    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl-devel \
+    intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel \
     g++ gfortran    \
     libopenmpi-dev  \
     openmpi-bin


### PR DESCRIPTION
oneAPI 2023.2.0 changed the naming of some `apt` packages. This fixes it.

Same as https://github.com/ECP-WarpX/WarpX/pull/4081