### PR TITLE
Use $(PYTHON) instead of python3 for sphinx docs build

### DIFF
--- a/Docs/Makefile
+++ b/Docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 PYTHON       ?= python
 SPHINXOPTS    =
-SPHINXBUILD   = python3 -msphinx
+SPHINXBUILD   = $(PYTHON) -msphinx
 SPHINXPROJ    = amrex
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
Use $(PYTHON) instead of python3 to mirror the build in the amrex docs