### PR TITLE
CI: Fix HIP Builds

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -31,6 +31,7 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     gfortran        \
+    hiprand-dev     \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -246,7 +246,7 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-pass-failed"}
+    env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-pass-failed"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/Evolve.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/CUDA/Evolve.cpp
@@ -9,9 +9,9 @@ using namespace amrex;
 Real compute_dt(const Geometry& geom, const amrex::Real& cfl)
 {
     const Real* dx = geom.CellSize();
-    const Real dt  = cfl * 1./( std::sqrt(D_TERM(  1./(dx[0]*dx[0]),
-                                                 + 1./(dx[1]*dx[1]),
-                                                 + 1./(dx[2]*dx[2]))) * PhysConst::c );
+    const Real dt  = cfl * 1./( std::sqrt(AMREX_D_TERM(  1./(dx[0]*dx[0]),
+                                                       + 1./(dx[1]*dx[1]),
+                                                       + 1./(dx[2]*dx[2]))) * PhysConst::c );
     return dt;
 }
 

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenACC/Evolve.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenACC/Evolve.cpp
@@ -8,9 +8,9 @@ using namespace amrex;
 Real compute_dt(const Geometry& geom, const amrex::Real& cfl)
 {
     const Real* dx = geom.CellSize();
-    const Real dt  = cfl * 1./( std::sqrt(D_TERM(  1./(dx[0]*dx[0]),
-                                                 + 1./(dx[1]*dx[1]),
-                                                 + 1./(dx[2]*dx[2]))) * PhysConst::c );
+    const Real dt  = cfl * 1./( std::sqrt(AMREX_D_TERM(  1./(dx[0]*dx[0]),
+                                                       + 1./(dx[1]*dx[1]),
+                                                       + 1./(dx[2]*dx[2]))) * PhysConst::c );
     return dt;
 }
 

--- a/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenMP/Evolve.cpp
+++ b/ExampleCodes/Particles/ElectromagneticPIC/Exec/OpenMP/Evolve.cpp
@@ -8,9 +8,9 @@ using namespace amrex;
 Real compute_dt(const Geometry& geom, const amrex::Real& cfl)
 {
     const Real* dx = geom.CellSize();
-    const Real dt  = cfl * 1./( std::sqrt(D_TERM(  1./(dx[0]*dx[0]),
-                                                 + 1./(dx[1]*dx[1]),
-                                                 + 1./(dx[2]*dx[2]))) * PhysConst::c );
+    const Real dt  = cfl * 1./( std::sqrt(AMREX_D_TERM(  1./(dx[0]*dx[0]),
+                                                       + 1./(dx[1]*dx[1]),
+                                                       + 1./(dx[2]*dx[2]))) * PhysConst::c );
     return dt;
 }
 


### PR DESCRIPTION
Add `hiprand-dev` package.
Allow operator names (in ROCm headers).

Unbreak CUDA builds: `D_TERM` -> `AMREX_D_TERM`