### PR TITLE
Copy new state to old in time integration example

### DIFF
--- a/ExampleCodes/SUNDIALS/Source/main.cpp
+++ b/ExampleCodes/SUNDIALS/Source/main.cpp
@@ -195,8 +195,8 @@ void main_main ()
         // advance from state_old at time to state_new at time + dt
         integrator.advance(state_old, state_new, time, dt);
 
-        // swap old/new and update time by dt
-        std::swap(state_old, state_new);
+        // update old state and update time by dt
+        amrex::MultiFab::Copy(state_old[0], state_new[0], 0, 0, Ncomp, Nghost);
         time += dt;
 
         // Tell the I/O Processor to write out which step we're doing


### PR DESCRIPTION
Using `swap` gives unexpected results. When writing output every step, the even step outputs are identical to the prior odd step.