### PR TITLE
STL example code

### DIFF
--- a/ExampleCodes/EB/STLtest/inputs
+++ b/ExampleCodes/EB/STLtest/inputs
@@ -3,11 +3,11 @@ eb2.stl_file              = airfoil.stl
 
 eb2.stl_scale             = 1                   # default is 1
 eb2.stl_center            = 0      0      0     # default is (0,0,0)
-eb2.stl_reverse_normal    = 1                   # default is 0. use "1" to see the volume of the stl object 
+eb2.stl_reverse_normal    = 0                   # default is 0.
 
-eb2.prob_lo               = 0      0      0
-eb2.prob_hi               = 220    35     60
-eb2.ncells                = 128    32     64
+prob_lo               = 0      0      0
+prob_hi               = 220    35     60
+ncells                = 128    32     64
 
-eb2.max_grid_size         = 8
-eb2.outside_point         = 250.0  250.0  250.0
+max_grid_size         = 8
+

--- a/ExampleCodes/EB/STLtest/inputs
+++ b/ExampleCodes/EB/STLtest/inputs
@@ -1,6 +1,13 @@
-prob_lo=  0   0  0
-prob_hi=  220 35 60
-ncells =  128 32 64
-stl_file=airfoil.stl
-max_grid_size=8
-outside_point=250.0 250.0 250.0
+eb2.geom_type             = stl
+eb2.stl_file              = airfoil.stl
+
+eb2.stl_scale             = 1                   # default is 1
+eb2.stl_center            = 0      0      0     # default is (0,0,0)
+eb2.stl_reverse_normal    = 1                   # default is 0. use "1" to see the volume of the stl object 
+
+eb2.prob_lo               = 0      0      0
+eb2.prob_hi               = 220    35     60
+eb2.ncells                = 128    32     64
+
+eb2.max_grid_size         = 8
+eb2.outside_point         = 250.0  250.0  250.0

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -58,8 +58,7 @@ int main (int argc, char* argv[])
         int max_coarsening_level = 0;    // typically a huge number so MG coarsens as much as possible
         // build a simple geometry using the "eb2." parameters in the inputs file
         EB2::Build(geom, required_coarsening_level, max_coarsening_level);
-        
-        //write plot file
+
         std::string pltfile;
         auto const& factory = makeEBFabFactory(geom, ba, dm, {1,1,1}, EBSupport::full);
         MultiFab const& vfrc = factory->getVolFrac();

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -57,7 +57,12 @@ int main (int argc, char* argv[])
         std::string pltfile;
         auto const& factory = makeEBFabFactory(geom, ba, dm, {1,1,1}, EBSupport::full);
         MultiFab const& vfrc = factory->getVolFrac();
-        amrex::WriteMLMF("plt", {&vfrc}, {geom});
+        MultiFab object(ba,dm,1,0); 
+        object.setVal(1.0);  
+        
+        MultiFab::Subtract(object, vfrc, 0,0,1,0);
+        amrex::WriteMLMF("plt", {&object}, {geom});
+
     }
 
     amrex::Finalize();

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -56,10 +56,9 @@ int main (int argc, char* argv[])
 
         int required_coarsening_level = 0; // typically the same as the max AMR level index
         int max_coarsening_level = 0;    // typically a huge number so MG coarsens as much as possible
-        
         // build a simple geometry using the "eb2." parameters in the inputs file
         EB2::Build(geom, required_coarsening_level, max_coarsening_level);
-
+        
         //write plot file
         std::string pltfile;
         auto const& factory = makeEBFabFactory(geom, ba, dm, {1,1,1}, EBSupport::full);

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -19,20 +19,15 @@ int main (int argc, char* argv[])
         int nghost = 1;
         int max_grid_size=64;
 
-        std::string stl_fname;
-
         Vector<Real> plo;
         Vector<Real> phi;
-        Vector<int> ncells;
-        Vector<Real> pointoutside;
+        Vector<int>  ncells;
         Real dx[3];
 
-        amrex::ParmParse pp("eb2");
-        pp.get("stl_file",stl_fname);
+        amrex::ParmParse pp;
         pp.getarr("prob_lo",plo);
         pp.getarr("prob_hi",phi);
         pp.getarr("ncells",ncells);
-        pp.getarr("outside_point",pointoutside);
         pp.query("max_grid_size",max_grid_size);
 
         RealBox real_box({AMREX_D_DECL(plo[0], plo[1], plo[2])},

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -49,16 +49,15 @@ int main (int argc, char* argv[])
         DistributionMapping dm(ba);
 
         int required_coarsening_level = 0; // typically the same as the max AMR level index
-        int max_coarsening_level = 0;    // typically a huge number so MG coarsens as much as possible
+        int max_coarsening_level = 0; // typically a huge number so MG coarsens as much as possible
         // build a simple geometry using the "eb2." parameters in the inputs file
         EB2::Build(geom, required_coarsening_level, max_coarsening_level);
 
         std::string pltfile;
         auto const& factory = makeEBFabFactory(geom, ba, dm, {1,1,1}, EBSupport::full);
         MultiFab const& vfrc = factory->getVolFrac();
-        MultiFab object(ba,dm,1,0); 
-        object.setVal(1.0);  
-        
+        MultiFab object(ba,dm,1,0);
+        object.setVal(1.0);
         MultiFab::Subtract(object, vfrc, 0,0,1,0);
         amrex::WriteMLMF("plt", {&object}, {geom});
     }

--- a/ExampleCodes/EB/STLtest/main.cpp
+++ b/ExampleCodes/EB/STLtest/main.cpp
@@ -14,7 +14,6 @@ using namespace amrex;
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
-
     {
         int nghost = 1;
         int max_grid_size=64;
@@ -62,8 +61,6 @@ int main (int argc, char* argv[])
         
         MultiFab::Subtract(object, vfrc, 0,0,1,0);
         amrex::WriteMLMF("plt", {&object}, {geom});
-
     }
-
     amrex::Finalize();
 }


### PR DESCRIPTION
I noticed that the example code for the STL test main file needed some edits, as EB2::Build has been updated. The current example inputs file is not compatible with the latest AMReX codes. 