### PR TITLE
fix(SWFFT/Poisson)

### DIFF
--- a/ExampleCodes/SWFFT/SWFFT_poisson/swfft_solver.cpp
+++ b/ExampleCodes/SWFFT/SWFFT_poisson/swfft_solver.cpp
@@ -70,7 +70,6 @@ swfft_solver(MultiFab& rhs, MultiFab& soln, Geometry& geom, int verbose)
     Real start_time = amrex::second();
 
     // Assume for now that nx = ny = nz
-    
     int Ndims[3] = { nbz, nby, nbx };
     int     n[3] = {domain.length(2), domain.length(1), domain.length(0)};
     hacc::Distribution d(MPI_COMM_WORLD,n,Ndims,&rank_mapping[0]);


### PR DESCRIPTION
- rank-mapping didn't have to be modified from fortran to C order, already carried out.
- already done so in SWFFT/Simple.