### PR TITLE
CI: Python Install Dependencies

### DIFF
--- a/.github/workflows/dependencies/dependencies.sh
+++ b/.github/workflows/dependencies/dependencies.sh
@@ -17,4 +17,5 @@ sudo apt-get install -y --no-install-recommends\
     python3         \
     python3-pip
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel

--- a/.github/workflows/dependencies/dependencies_clang6.sh
+++ b/.github/workflows/dependencies/dependencies_clang6.sh
@@ -15,4 +15,5 @@ sudo apt-get install -y  \
     python3              \
     python3-pip
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel

--- a/.github/workflows/dependencies/dependencies_gcc10.sh
+++ b/.github/workflows/dependencies/dependencies_gcc10.sh
@@ -18,4 +18,5 @@ sudo apt-get install -y --no-install-recommends \
     python3            \
     python3-pip
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel

--- a/.github/workflows/dependencies/dependencies_nofortran.sh
+++ b/.github/workflows/dependencies/dependencies_nofortran.sh
@@ -21,4 +21,5 @@ sudo apt-get install -y --no-install-recommends\
     python3         \
     python3-pip
 
-python3 -m pip install -U pip setuptools wheel
+python3 -m pip install -U pip
+python3 -m pip install -U build packaging setuptools wheel


### PR DESCRIPTION
Update the Python install dependencies according to latest docs. Setuptools had a breaking change for Python 3.12 and we modernized accordingly.
https://github.com/AMReX-Codes/pyamrex/pull/180

Also, there is some recent Pip issue on old Ubuntu 20.04:
https://github.com/AMReX-Codes/pyamrex/pull/340
but this seems to be fine here now.