### PR TITLE
CMake: Replace `FetchContent_Populate`

### DIFF
--- a/ExampleCodes/CMakeLists.txt
+++ b/ExampleCodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.24)
 
 project( AMReX-Tutorials
    DESCRIPTION "Tutorials for the AMReX adaptive mesh refinement framework"
@@ -50,6 +50,14 @@ if( NOT DEFINED AMReX_DIR )
 
    set(AMReX_GIT_BRANCH "development" CACHE STRING "The AMReX branch to checkout")
    set(AMReX_INSTALL  "NO" CACHE INTERNAL "Disable install target for amrex")
+
+   if(AMReX_FORTRAN)
+      enable_language(Fortran)
+   endif ()
+
+   if(AMReX_GPU_BACKEND STREQUAL "CUDA")
+      enable_language(CUDA)
+   endif()
 
    include(FetchContent)
    set(FETCHCONTENT_QUIET OFF)  # Verbose ON
@@ -164,10 +172,6 @@ endif ()
 
        if(AMReX_GPU_BACKEND STREQUAL "CUDA")
           enable_language(CUDA)
-          # AMReX 21.06+ supports CUDA_ARCHITECTURES
-          if(CMAKE_VERSION VERSION_LESS 3.20)
-             include(AMReX_SetupCUDA)
-          endif()
        endif()
    endif()
 else()
@@ -178,10 +182,6 @@ else()
 
    if(AMReX_GPU_BACKEND STREQUAL "CUDA")
       enable_language(CUDA)
-      # AMReX 21.06+ supports CUDA_ARCHITECTURES
-      if(CMAKE_VERSION VERSION_LESS 3.20)
-         include(AMReX_SetupCUDA)
-      endif()
    endif()
 endif()
 

--- a/ExampleCodes/CMakeLists.txt
+++ b/ExampleCodes/CMakeLists.txt
@@ -59,14 +59,14 @@ if( NOT DEFINED AMReX_DIR )
        GIT_TAG        ${AMReX_GIT_BRANCH}
        )
 
-   if(NOT ${amrex}_POPULATED)
-       FetchContent_Populate(amrex)
+if(NOT ${amrex}_POPULATED)
+   FetchContent_MakeAvailable(amrex)
 
-       list(APPEND CMAKE_MODULE_PATH ${amrex_SOURCE_DIR}/Tools/CMake)
+   list(APPEND CMAKE_MODULE_PATH ${amrex_SOURCE_DIR}/Tools/CMake)
 
-       # Load amrex options here so that they are
-       # available to the entire project
-       include(AMReXOptions)
+   # Load amrex options here so that they are
+   # available to the entire project
+   include(AMReXOptions)
 
 if( AMReX_SUNDIALS )
 if( NOT DEFINED SUNDIALS_DIR )
@@ -86,7 +86,7 @@ if( NOT DEFINED SUNDIALS_DIR )
        )
 
    if(NOT ${sundials}_POPULATED)
-       FetchContent_Populate(sundials)
+       FetchContent_MakeAvailable(sundials)
 #       set(SUNDIALS_DIR ${sundials_SOURCE_DIR})
    # Set build options for subproject
    set(EXAMPLES_ENABLE_C            OFF                        CACHE INTERNAL "" )
@@ -121,9 +121,6 @@ if( NOT DEFINED SUNDIALS_DIR )
    set(BUILD_CVODES                 OFF                        CACHE INTERNAL "" )
 endif ()
    list(APPEND CMAKE_MODULE_PATH ${sundials_SOURCE_DIR})
-
-#  Add  SUNDIALS sources to the build
-   add_subdirectory(${sundials_SOURCE_DIR})
 
    # This is to use the same target name uses by the sundials exported targets
    add_library(SUNDIALS::cvode      ALIAS sundials_cvode_static)
@@ -172,9 +169,6 @@ endif ()
              include(AMReX_SetupCUDA)
           endif()
        endif()
-
-       # Bring the populated content into the build
-       add_subdirectory(${amrex_SOURCE_DIR} ${amrex_BINARY_DIR})
    endif()
 else()
    message(STATUS "Using existing AMReX library")
@@ -210,10 +204,8 @@ if(TUTORIAL_PYTHON)
            GIT_REPOSITORY ${pyAMReX_GIT_REPO}
            GIT_TAG        ${pyAMReX_GIT_BRANCH}
            )
-
        if(NOT fetchedpyamrex_POPULATED)
-           FetchContent_Populate(fetchedpyamrex)
-           add_subdirectory(${fetchedpyamrex_SOURCE_DIR} ${fetchedpyamrex_BINARY_DIR})
+           FetchContent_MakeAvailable(fetchedpyamrex)
        endif()
     endif()
 endif()

--- a/GuidedTutorials/HeatEquation/Exec/CMakeLists.txt
+++ b/GuidedTutorials/HeatEquation/Exec/CMakeLists.txt
@@ -57,11 +57,7 @@ if(NOT DEFINED AMReX_ROOT)
     GIT_TAG        origin/development
     )
 
-  FetchContent_Populate(amrex_code)
-
-  # CMake will read the files in these directories and configure, build
-  # and install AMReX.
-  add_subdirectory(${amrex_code_SOURCE_DIR} ${amrex_code_BINARY_DIR})
+  FetchContent_MakeAvailable(amrex_code)
 
 else()
 

--- a/GuidedTutorials/HeatEquation/Exec/CMakeLists.txt
+++ b/GuidedTutorials/HeatEquation/Exec/CMakeLists.txt
@@ -28,7 +28,7 @@
 # For additional CMake compile options see
 # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#building-with-cmake
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 ## Project name and source file languages
 project(HeatEquation_EX0

--- a/GuidedTutorials/HeatEquation_Simple/CMakeLists.txt
+++ b/GuidedTutorials/HeatEquation_Simple/CMakeLists.txt
@@ -49,11 +49,7 @@ if(NOT DEFINED AMReX_ROOT)
     GIT_TAG        origin/development
     )
 
-  FetchContent_Populate(amrex_code)
-
-  # CMake will read the files in these directories to configure, build
-  # and install AMReX.
-  add_subdirectory(${amrex_code_SOURCE_DIR} ${amrex_code_BINARY_DIR})
+  FetchContent_MakeAvailable(amrex_code)
 
 else()
 

--- a/GuidedTutorials/HeatEquation_Simple/CMakeLists.txt
+++ b/GuidedTutorials/HeatEquation_Simple/CMakeLists.txt
@@ -24,7 +24,7 @@
 # For additional CMake compile options see
 # https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#building-with-cmake
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 # Project name and source file languages
 project(HeatEquation_Simple

--- a/GuidedTutorials/HelloWorld/CMakeLists.txt
+++ b/GuidedTutorials/HelloWorld/CMakeLists.txt
@@ -53,11 +53,7 @@ if(NOT DEFINED AMReX_ROOT)
     GIT_TAG        origin/development
     )
 
-  FetchContent_Populate(amrex_code)
-
-  # CMake will read the files in these directories and configure, build
-  # and install AMReX.
-  add_subdirectory(${amrex_code_SOURCE_DIR} ${amrex_code_BINARY_DIR})
+  FetchContent_MakeAvailable(amrex_code)
 
 else()
 

--- a/GuidedTutorials/HelloWorld/CMakeLists.txt
+++ b/GuidedTutorials/HelloWorld/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 # Project name and source file language
 project(HelloWorld

--- a/GuidedTutorials/MultiFab/CMakeLists.txt
+++ b/GuidedTutorials/MultiFab/CMakeLists.txt
@@ -53,11 +53,7 @@ if(NOT DEFINED AMReX_ROOT)
     GIT_TAG        origin/development
     )
 
-  FetchContent_Populate(amrex_code)
-
-  # CMake will read the files in these directories and configure, build
-  # and install AMReX.
-  add_subdirectory(${amrex_code_SOURCE_DIR} ${amrex_code_BINARY_DIR})
+  FetchContent_MakeAvailable(amrex_code)
 
 else()
 

--- a/GuidedTutorials/MultiFab/CMakeLists.txt
+++ b/GuidedTutorials/MultiFab/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 # Project name and source file language
 project(MultiFab


### PR DESCRIPTION
In CMake superbuilds, `FetchContent_Populate` is now deprecated. Use `FetchContent_MakeAvailable` instead.

- [x] Bump CMake to 2.24+ to have the [latest behavioral changes](https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_makeavailable) in it. We anyway need a bump as we will soon rework the CUDA/HIP language support from AMReX to downstream.

See https://github.com/AMReX-Codes/pyamrex/pull/359