### PR TITLE
Correction of the computation of the energy spectrum

### DIFF
--- a/ExampleCodes/FFT/EnergySpectrum/main.cpp
+++ b/ExampleCodes/FFT/EnergySpectrum/main.cpp
@@ -23,7 +23,7 @@ int main (int argc, char* argv[])
         cMultiFab cx, cy, cz;
         {
             // Note that the complex Hermitian output array Y has (nx/2+1,ny,nz) elements.
-	    // Y[nx-i,j,k] = Y[i,j,k]*
+            // Y[nx-i,j,k] = Y[i,j,k]*
             FFT::R2C<Real,FFT::Direction::forward> fft(geom.Domain());
             auto const& [ba, dm] = fft.getSpectralDataLayout();
             cx.define(ba,dm,1,0);
@@ -57,10 +57,10 @@ int main (int argc, char* argv[])
                 Real value = amrex::norm(cxa[b](i,j,k))
                     +        amrex::norm(cya[b](i,j,k))
                     +        amrex::norm(cza[b](i,j,k));
-		// Account for Hermitian symmetry in x-direction
-	        // Hermitian symmetry Y[nx-i,j,k] = Y[i,j,k]*
+                // Account for Hermitian symmetry in x-direction
+                // Hermitian symmetry Y[nx-i,j,k] = Y[i,j,k]*
                 if ((i > 0) && (2*i != nx)) {
-		    // Multiply by 2 because we have +ki and -ki
+                    // Multiply by 2 because we have +ki and -ki
                     value *= Real(2.0);
                 }
                 HostDevice::Atomic::Add(pke+di, value);

--- a/ExampleCodes/FFT/EnergySpectrum/main.cpp
+++ b/ExampleCodes/FFT/EnergySpectrum/main.cpp
@@ -59,8 +59,9 @@ int main (int argc, char* argv[])
                     +        amrex::norm(cza[b](i,j,k));
 		// Account for Hermitian symmetry in x-direction
 	        // Hermitian symmetry Y[nx-i,j,k] = Y[i,j,k]*
-                if (i > 0) { // Avoid double-counting at kx = 0
-                    value *= 2.0; // Multiply by 2 because we have kx and -kx
+                if ((i > 0) && (2*i != nx)) {
+		    // Multiply by 2 because we have +ki and -ki
+                    value *= 2.0;
                 }
                 HostDevice::Atomic::Add(pke+di, value);
             }

--- a/ExampleCodes/FFT/EnergySpectrum/main.cpp
+++ b/ExampleCodes/FFT/EnergySpectrum/main.cpp
@@ -61,7 +61,7 @@ int main (int argc, char* argv[])
 	        // Hermitian symmetry Y[nx-i,j,k] = Y[i,j,k]*
                 if ((i > 0) && (2*i != nx)) {
 		    // Multiply by 2 because we have +ki and -ki
-                    value *= 2.0;
+                    value *= Real(2.0);
                 }
                 HostDevice::Atomic::Add(pke+di, value);
             }


### PR DESCRIPTION
As discussed here: [https://github.com/AMReX-Codes/amrex-tutorials/issues/153](https://github.com/AMReX-Codes/amrex-tutorials/issues/153), here is a correction for the energy spectrum calculation.

The ParallelFor now loops on 0,1,2,...,nx 0,1,2,...,ny and 0,1,2,...,nz with a change of i index if i > nx/2 to take into account the Hermitian symmetry of the R2C output array.

I verified that the output spectrum is correct by comparing with C2C which outputs the full array.