### PR TITLE
Fix GNUmake

### DIFF
--- a/ExampleCodes/Basic/HeatEquation_EX0_C/Exec/GNUmakefile
+++ b/ExampleCodes/Basic/HeatEquation_EX0_C/Exec/GNUmakefile
@@ -11,7 +11,7 @@ include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 include ../Source/Make.package
 VPATH_LOCATIONS  += ../Source
-INCLUDE_LOCATIONS += ./Source
+INCLUDE_LOCATIONS += ../Source
 
 include $(AMREX_HOME)/Src/Base/Make.package
 


### PR DESCRIPTION
Cleans up a warning thrown currently:

f951: Warning: Nonexistent include directory ‘./Source’ [-Wmissing-include-dirs]
